### PR TITLE
added HAOS customizations for user selected entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
+ha_dashboard_entities.json
 pi4-dashboard-workspace.code-workspace

--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
+import json
 import os
 import random
 import re
+import tempfile
 from flask import Flask, render_template, request, jsonify, redirect
 import requests
 import logging
@@ -22,10 +24,48 @@ HA_ACCESS_TOKEN = os.environ.get("HA_ACCESS_TOKEN") or ""
 # Shelly (or other) temp/humidity sensor entity IDs for "Inside" on dashboard (e.g. sensor.shelly_plus_ht_xxx_temperature).
 HA_INSIDE_TEMP_ENTITY = (os.environ.get("HA_INSIDE_TEMP_ENTITY") or "").strip()
 HA_INSIDE_HUMIDITY_ENTITY = (os.environ.get("HA_INSIDE_HUMIDITY_ENTITY") or "").strip()
+# Path to JSON file storing which HA entities to show on dashboard (null = use default: domains minus EXCLUDED).
+HA_DASHBOARD_ENTITIES_FILE = os.environ.get(
+    "HA_DASHBOARD_ENTITIES_FILE",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "ha_dashboard_entities.json"),
+)
 
 
 def _ha_configured() -> bool:
     return bool(HA_URL and HA_ACCESS_TOKEN)
+
+
+def _load_ha_dashboard_entities() -> dict | None:
+    """Load visible_entity_ids from JSON file. Returns None if file missing/invalid (use default behavior)."""
+    if not os.path.isfile(HA_DASHBOARD_ENTITIES_FILE):
+        return None
+    try:
+        with open(HA_DASHBOARD_ENTITIES_FILE, encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        return data
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _save_ha_dashboard_entities(visible_entity_ids: list[str] | None) -> None:
+    """Persist visible_entity_ids to JSON file. None = reset to default."""
+    data = {"visible_entity_ids": visible_entity_ids}
+    try:
+        fd, path = tempfile.mkstemp(dir=os.path.dirname(HA_DASHBOARD_ENTITIES_FILE), prefix="ha_entities.", suffix=".json")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            os.replace(path, HA_DASHBOARD_ENTITIES_FILE)
+        except Exception:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            raise
+    except OSError as e:
+        log.warning("Could not save HA dashboard entities: %s", e)
 
 
 def _load_weather_quote() -> tuple[str, str] | None:
@@ -56,7 +96,7 @@ def _load_weather_quote() -> tuple[str, str] | None:
 @app.after_request
 def _disable_cache_for_dashboard(response):
     """Prevent browsers from caching dashboard HTML so updates show after deploy."""
-    if request.path in ("/", "/5day", "/ha") and response.content_type and "text/html" in response.content_type:
+    if request.path in ("/", "/5day", "/ha", "/ha/settings") and response.content_type and "text/html" in response.content_type:
         response.cache_control.no_store = True
         response.cache_control.no_cache = True
         response.cache_control.must_revalidate = True
@@ -455,11 +495,49 @@ def ha_service():
         return jsonify({"error": str(e)}), 500
 
 
+@app.route("/api/ha/dashboard-entities", methods=["GET"])
+def ha_dashboard_entities_get():
+    """Return saved allowlist for dashboard: { visible_entity_ids: [...] } or null for default."""
+    if not _ha_configured():
+        return jsonify({"error": "HA not configured"}), 503
+    data = _load_ha_dashboard_entities()
+    if data is None:
+        return jsonify({"visible_entity_ids": None})
+    return jsonify({"visible_entity_ids": data.get("visible_entity_ids")})
+
+
+@app.route("/api/ha/dashboard-entities", methods=["PUT"])
+def ha_dashboard_entities_put():
+    """Save allowlist. Body: { visible_entity_ids: ["light.x", ...] } or null to reset to default."""
+    if not _ha_configured():
+        return jsonify({"error": "HA not configured"}), 503
+    payload = request.get_json(silent=True)
+    if payload is None:
+        visible = None
+    else:
+        visible = payload.get("visible_entity_ids")
+        if visible is not None and not isinstance(visible, list):
+            return jsonify({"error": "visible_entity_ids must be an array or null"}), 400
+        if visible is not None:
+            visible = [str(e).strip() for e in visible if str(e).strip()]
+    _save_ha_dashboard_entities(visible)
+    return jsonify({"visible_entity_ids": visible})
+
+
 @app.route("/ha")
 def ha_dashboard():
     """Third page: Home Assistant controls. Token not in template."""
     return render_template(
         "dashboard_ha.html",
+        ha_configured=_ha_configured(),
+    )
+
+
+@app.route("/ha/settings")
+def ha_dashboard_settings():
+    """Picker page: choose which HA entities appear on the dashboard."""
+    return render_template(
+        "dashboard_ha_settings.html",
         ha_configured=_ha_configured(),
     )
 

--- a/templates/dashboard_ha.html
+++ b/templates/dashboard_ha.html
@@ -26,6 +26,9 @@
         .control-card input[type="range"]::-moz-range-thumb { width: 14px; height: 14px; border-radius: 50%; background: #ff9f0a; cursor: pointer; border: none; }
         .error-msg { color: #c00; padding: 10px 0; }
         .loading { color: #888; padding: 20px; }
+        .picker-link { margin: 0 0 12px 0; }
+        .picker-link a { color: #ff9f0a; text-decoration: none; font-size: 14px; }
+        .picker-link a:hover { text-decoration: underline; }
     </style>
     <meta http-equiv="refresh" content="300">
 </head>
@@ -40,6 +43,7 @@
         <div class="ha-unconfigured">Home Assistant not configured. Set HA_URL and HA_ACCESS_TOKEN in the environment.</div>
         {% else %}
         <div id="controls-root">
+            <p class="picker-link"><a href="/ha/settings">Choose which controls to show</a></p>
             <div class="loading" id="loading">Loading…</div>
             <div class="error-msg" id="error" style="display: none;"></div>
             <div class="controls-grid" id="controls" style="display: none;"></div>
@@ -72,7 +76,7 @@
     function renderStates(states) {
         var container = document.getElementById('controls');
         var loading = document.getElementById('loading');
-        states = (states || []).filter(function(s) { return !isExcluded(s); });
+        states = states || [];
         if (states.length === 0) {
             loading.textContent = 'No lights or fans found.';
             container.style.display = 'none';
@@ -160,20 +164,33 @@
 
     function fetchStates() {
         var q = '?domain=' + DOMAINS.join(',');
-        fetch('/api/ha/states' + q)
-            .then(function(r) {
+        Promise.all([
+            fetch('/api/ha/states' + q).then(function(r) {
                 if (!r.ok) return r.json().then(function(j) { throw new Error(j.error || r.statusText); });
                 return r.json();
+            }),
+            fetch('/api/ha/dashboard-entities').then(function(r) {
+                if (!r.ok) return { visible_entity_ids: null };
+                return r.json();
             })
-            .then(function(states) {
-                showError('');
-                renderStates(states);
-            })
-            .catch(function(e) {
-                showError('Could not load states: ' + e.message);
-                document.getElementById('loading').style.display = 'none';
-                document.getElementById('controls').style.display = 'none';
-            });
+        ]).then(function(results) {
+            var states = results[0];
+            var config = results[1] || {};
+            var allowlist = config.visible_entity_ids;
+            if (allowlist && Array.isArray(allowlist) && allowlist.length > 0) {
+                var set = {};
+                allowlist.forEach(function(id) { set[id] = true; });
+                states = (states || []).filter(function(s) { return set[s.entity_id]; });
+            } else {
+                states = (states || []).filter(function(s) { return !isExcluded(s); });
+            }
+            showError('');
+            renderStates(states);
+        }).catch(function(e) {
+            showError('Could not load states: ' + e.message);
+            document.getElementById('loading').style.display = 'none';
+            document.getElementById('controls').style.display = 'none';
+        });
     }
 
     fetchStates();

--- a/templates/dashboard_ha_settings.html
+++ b/templates/dashboard_ha_settings.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body { background: #000; color: #fff; font-family: sans-serif; margin: 0; overflow: hidden; display: flex; flex-direction: column; height: 100vh; }
+        .nav { display: flex; gap: 12px; padding: 12px 20px; background: #111; border-top: 1px solid #333; flex-wrap: wrap; }
+        .nav a { display: inline-block; padding: 14px 28px; background: #333; color: #ff9f0a; text-decoration: none; font-size: 20px; font-weight: bold; border-radius: 8px; }
+        .nav a:hover, .nav a.active { background: #ff9f0a; color: #000; }
+        .content { flex: 1; overflow-y: auto; padding: 16px; }
+        .ha-unconfigured { color: #888; font-size: 18px; padding: 20px; }
+        .section { margin-bottom: 24px; }
+        .section h2 { color: #ff9f0a; font-size: 18px; margin: 0 0 10px 0; }
+        .entity-row { display: flex; align-items: center; gap: 10px; padding: 8px 0; border-bottom: 1px solid #222; }
+        .entity-row label { display: flex; align-items: center; gap: 8px; cursor: pointer; flex: 1; }
+        .entity-row input[type="checkbox"] { width: 18px; height: 18px; accent-color: #ff9f0a; }
+        .entity-name { color: #fff; font-weight: bold; }
+        .entity-id { color: #666; font-size: 12px; }
+        .section-actions { margin-top: 6px; }
+        .section-actions button { padding: 6px 12px; margin-right: 8px; background: #333; color: #ff9f0a; border: none; border-radius: 6px; cursor: pointer; font-size: 12px; }
+        .section-actions button:hover { background: #ff9f0a; color: #000; }
+        .global-actions { margin-top: 20px; padding-top: 16px; border-top: 1px solid #333; }
+        .global-actions button { padding: 12px 24px; margin-right: 10px; background: #333; color: #ff9f0a; border: none; border-radius: 8px; cursor: pointer; font-size: 16px; font-weight: bold; }
+        .global-actions button:hover { background: #ff9f0a; color: #000; }
+        .global-actions button.primary { background: #ff9f0a; color: #000; }
+        .global-actions button.primary:hover { background: #e08d00; }
+        .loading { color: #888; padding: 20px; }
+        .error-msg { color: #c00; padding: 10px 0; }
+        .success-msg { color: #0a0; padding: 10px 0; }
+    </style>
+</head>
+<body>
+    <nav class="nav">
+        <a href="/">Home</a>
+        <a href="/5day">5 Day</a>
+        <a href="/ha">Controls</a>
+        <a href="/ha/settings" class="active">Choose controls</a>
+    </nav>
+    <div class="content">
+        {% if not ha_configured %}
+        <div class="ha-unconfigured">Home Assistant not configured. Set HA_URL and HA_ACCESS_TOKEN in the environment.</div>
+        {% else %}
+        <div id="picker-root">
+            <div class="loading" id="loading">Loading entities…</div>
+            <div class="error-msg" id="error" style="display: none;"></div>
+            <div id="sections" style="display: none;"></div>
+            <div class="global-actions" id="global-actions" style="display: none;">
+                <button type="button" class="primary" id="btn-save">Save and go to Controls</button>
+                <button type="button" id="btn-reset">Reset to show all (use defaults)</button>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+    <script>
+(function() {
+    if (!document.getElementById('sections')) return;
+    var DOMAINS = ['light', 'switch', 'fan'];
+    var DOMAIN_LABELS = { light: 'Lights', switch: 'Switches', fan: 'Fans' };
+
+    function showError(msg) {
+        var el = document.getElementById('error');
+        el.textContent = msg || '';
+        el.style.display = msg ? 'block' : 'none';
+    }
+
+    function escapeHtml(s) {
+        var div = document.createElement('div');
+        div.textContent = s;
+        return div.innerHTML;
+    }
+
+    function render(states, visibleSet) {
+        var byDomain = {};
+        DOMAINS.forEach(function(d) { byDomain[d] = []; });
+        (states || []).forEach(function(s) {
+            var domain = (s.entity_id || '').split('.')[0];
+            if (byDomain[domain]) byDomain[domain].push(s);
+        });
+        var container = document.getElementById('sections');
+        container.innerHTML = '';
+        DOMAINS.forEach(function(domain) {
+            var list = byDomain[domain];
+            if (list.length === 0) return;
+            var section = document.createElement('div');
+            section.className = 'section';
+            var label = DOMAIN_LABELS[domain] || domain;
+            section.innerHTML = '<h2>' + escapeHtml(label) + '</h2><div class="section-actions"><button type="button" data-domain="' + escapeHtml(domain) + '" data-check="true">Select all</button><button type="button" data-domain="' + escapeHtml(domain) + '" data-check="false">Deselect all</button></div><div class="entity-list" data-domain="' + escapeHtml(domain) + '"></div>';
+            var listEl = section.querySelector('.entity-list');
+            list.forEach(function(s) {
+                var entityId = s.entity_id || '';
+                var name = (s.attributes && s.attributes.friendly_name) || entityId;
+                var checked = visibleSet[entityId];
+                var row = document.createElement('div');
+                row.className = 'entity-row';
+                row.innerHTML = '<label><input type="checkbox" data-entity-id="' + escapeHtml(entityId) + '" ' + (checked ? 'checked' : '') + '><span class="entity-name">' + escapeHtml(name) + '</span><span class="entity-id">' + escapeHtml(entityId) + '</span></label>';
+                listEl.appendChild(row);
+            });
+            section.querySelectorAll('.section-actions button').forEach(function(btn) {
+                btn.addEventListener('click', function() {
+                    var check = btn.getAttribute('data-check') === 'true';
+                    listEl.querySelectorAll('input[type="checkbox"]').forEach(function(cb) {
+                        cb.checked = check;
+                    });
+                });
+            });
+            container.appendChild(section);
+        });
+        document.getElementById('loading').style.display = 'none';
+        document.getElementById('sections').style.display = 'block';
+        document.getElementById('global-actions').style.display = 'block';
+    }
+
+    function getVisibleSet(visibleIds) {
+        var set = {};
+        if (visibleIds && Array.isArray(visibleIds)) visibleIds.forEach(function(id) { set[id] = true; });
+        return set;
+    }
+
+    function getCheckedIds() {
+        var ids = [];
+        document.querySelectorAll('#sections input[type="checkbox"]:checked').forEach(function(cb) {
+            ids.push(cb.getAttribute('data-entity-id'));
+        });
+        return ids;
+    }
+
+    function load() {
+        var q = '?domain=' + DOMAINS.join(',');
+        Promise.all([
+            fetch('/api/ha/states' + q).then(function(r) {
+                if (!r.ok) return r.json().then(function(j) { throw new Error(j.error || r.statusText); });
+                return r.json();
+            }),
+            fetch('/api/ha/dashboard-entities').then(function(r) {
+                if (!r.ok) return { visible_entity_ids: null };
+                return r.json();
+            })
+        ]).then(function(results) {
+            var states = results[0];
+            var config = results[1] || {};
+            var visibleIds = config.visible_entity_ids;
+            var visibleSet = {};
+            if (visibleIds && Array.isArray(visibleIds) && visibleIds.length > 0) {
+                visibleIds.forEach(function(id) { visibleSet[id] = true; });
+            } else {
+                (states || []).forEach(function(s) { visibleSet[s.entity_id] = true; });
+            }
+            showError('');
+            render(states, visibleSet);
+        }).catch(function(e) {
+            showError('Could not load: ' + e.message);
+            document.getElementById('loading').style.display = 'none';
+        });
+    }
+
+    document.getElementById('btn-save').addEventListener('click', function() {
+        showError('');
+        var ids = getCheckedIds();
+        fetch('/api/ha/dashboard-entities', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ visible_entity_ids: ids })
+        }).then(function(r) {
+            if (!r.ok) return r.json().then(function(j) { throw new Error(j.error || r.statusText); });
+            window.location.href = '/ha';
+        }).catch(function(e) {
+            showError('Save failed: ' + e.message);
+        });
+    });
+
+    document.getElementById('btn-reset').addEventListener('click', function() {
+        showError('');
+        fetch('/api/ha/dashboard-entities', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ visible_entity_ids: null })
+        }).then(function(r) {
+            if (!r.ok) return r.json().then(function(j) { throw new Error(j.error || r.statusText); });
+            window.location.href = '/ha';
+        }).catch(function(e) {
+            showError('Reset failed: ' + e.message);
+        });
+    });
+
+    load();
+})();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
. Backend 1
Config: HA_DASHBOARD_ENTITIES_FILE (env override, default ha_dashboard_entities.json next to app.py). Helpers: _load_ha_dashboard_entities() (returns file data or None), _save_ha_dashboard_entities(visible_entity_ids) (atomic write via temp file). GET /api/ha/dashboard-entities: Returns { "visible_entity_ids": [...] } or { "visible_entity_ids": null } when no file/default. PUT /api/ha/dashboard-entities: Body { "visible_entity_ids": ["light.x", ...] } or null to reset; validates and persists. Route /ha/settings: Serves the picker template; cache-control updated to include /ha/settings.
2. Dashboard 2 Link “Choose which controls to show” to /ha/settings (only when HA is configured). Load: fetches /api/ha/states and /api/ha/dashboard-entities. If visible_entity_ids is a non-empty array, only those entities are shown; otherwise current default (domains + EXCLUDED) is used. Filtering is done in the fetch callback; renderStates no longer applies EXCLUDED (filtering is centralized).
3. Picker 3 Same nav as HA dashboard, with “Choose controls” active. Loads entities for light, switch, fan and the current allowlist. If no allowlist is saved, every entity is checked (default = show all). Groups by domain (Lights, Switches, Fans) with “Select all” / “Deselect all” per section. Save and go to Controls: PUTs checked entity IDs and redirects to /ha. Reset to show all: PUTs visible_entity_ids: null and redirects to /ha.
4. Other ha_dashboard_entities.json added to .gitignore so per-environment choices are not committed. Flow: With no saved file, the dashboard behaves as before (domains + EXCLUDED). After using “Choose which controls to show”, checking entities, and saving, only those entities appear. “Reset to show all” clears the file so default behavior is used again.